### PR TITLE
CASMINST-3310: Revert commit to use correct base chart

### DIFF
--- a/kubernetes/cray-csm-barebones-recipe-install/requirements.yaml
+++ b/kubernetes/cray-csm-barebones-recipe-install/requirements.yaml
@@ -1,4 +1,5 @@
+---
 dependencies:
-- name: cray-service
-  version: "^5.0.0"
-  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
+  - name: cray-import-kiwi-recipe-image
+    version: "0.2.8"
+    repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"


### PR DESCRIPTION
Commit 9c059eef20fe865e4129fa95c7879a057a325543 mistakenly switched the base chart to be the cray-service chart, rather than the correct base chart (cray-import-kiwi-recipe-image). This caused problems, as one would expect. This PR simply reverts that portion of the original PR.

No testing has been conducted on this PR beyond making sure that the build succeeds.

In terms of risk, since the commit being reverted broke it, this PR can't really make it any worse, unless it somehow gives rise to malevolent AI that destroy humanity (although some may argue as to whether that would be worse or better).