### PR TITLE
CASMCMS-7617 Remove annotation for cray-product-catalog-update

### DIFF
--- a/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
+++ b/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
@@ -19,6 +19,4 @@ annotations:
   artifacthub.io/images: |
     - name: cray-csm-barebones-recipe-install
       image: artifactory.algol60.net/csm-docker/stable/cray-csm-sles15sp2-barebones-recipe:0.0.0
-    - name: cray-product-catalog-update
-      image: artifactory.algol60.net/csm-docker/stable/cray-product-catalog-update
   artifacthub.io/license: MIT


### PR DESCRIPTION
## Summary and Scope

Remove annotation for cray-product-catalog-update. This image is defined in the base chart and not in this chart. The image can be found by rendering the chart. Therefore, the image does not need to be listed in the annotations.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_ Yes

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7617](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7617)

## Testing

Not tested. This change does not affect the code.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

