### PR TITLE
CASMCMS-7728: Use placeholder version strings that are unlikely to collide with actual version strings

### DIFF
--- a/Dockerfile_csm-sles15sp2-barebones.image-recipe
+++ b/Dockerfile_csm-sles15sp2-barebones.image-recipe
@@ -21,7 +21,7 @@
 # (MIT License)
 
 # Dockerfile for image which holds the CSM barebones image (squashfs) and Kiwi recipe
-FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:9.9.9 as base
+FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-imsload as base
 
 # Use for testing/not in pipeline builds
 #FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:latest as base

--- a/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
+++ b/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-csm-barebones-recipe-install
-version: 0.0.0
+version: 0.0.0-recipe
 description: Kubernetes resources for cray-csm-barebones-recipe-install
 keywords:
 - ims
@@ -18,5 +18,5 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: cray-csm-barebones-recipe-install
-      image: artifactory.algol60.net/csm-docker/stable/cray-csm-sles15sp2-barebones-recipe:0.0.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-csm-sles15sp2-barebones-recipe:0.0.0-recipe
   artifacthub.io/license: MIT

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -15,9 +15,9 @@
 #sourcefile: v2.txt
 #targetfile: 1/2/3.txt
 
-tag: 0.0.0
+tag: 0.0.0-recipe
 targetfile: kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
 
 sourcefile: cray-ims-load-artifacts.version
-tag: 9.9.9
+tag: 0.0.0-imsload
 targetfile: Dockerfile_csm-sles15sp2-barebones.image-recipe


### PR DESCRIPTION
## Summary and Scope

This is the same as the followimg ims PR, except for the image-recipes repo:
https://github.com/Cray-HPE/ims/pull/22

## Issues and Related PRs

https://github.com/Cray-HPE/ims/pull/22

## Testing

None other than verifying that the build works ok.

## Risks and Mitigations

Low risk. No actual change being made to the artifact, just a detail of how it is building

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

