### PR TITLE
CASMCMS-7964 - Add label information to the image build.

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -71,6 +71,10 @@ pipeline {
         }
 
         stage("Build") {
+            environment {
+                DOCKER_VERSION = sh(returnStdout: true, script: "head -1 .docker_version").trim()
+                DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION, version: env.DOCKER_VERSION)
+            }
             parallel {
                 stage('Kiwi Image') {
                     steps {


### PR DESCRIPTION
## Summary and Scope

The docker arguments for adding label metadata information to the image need to be present for the automatic image rebuild scripts to figure out how to trigger a rebuild of a particular image. This calls the predefined functions that will set the needed arguments to get the correct metadata appended to the image at build time.

There is no change to the code or the content of the image being built, just the added metadata.

## Issues and Related PRs
* Resolves [CASMCMS-7964](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7964)

## Testing
### Tested on:
  * Local development environment

### Test description:
There is no change to the code or the actual image generated, just the metadata labels added to the image. The image was built through the pipeline when changes were pushed to the repo, I downloaded the new image and read the metadata labels - they now contain the correct information.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is very low risk - just adding metadata labels to the image so the automatic rebuild scripts can trigger a rebuild of the image.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

