### PR TITLE
CASMTRIAGE-3756 - fix file permission issues with image upload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - CASMTRIAGE-3756 - correct built image file permissions.
+- CASMCMS-7970 - ims update cray.dev.com addresses
 
 ## [1.5.0] - 2022-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMTRIAGE-3756 - correct built image file permissions.
 
 ## [1.5.0] - 2022-07-01
 

--- a/Dockerfile_csm-sles15sp3-barebones.image-recipe
+++ b/Dockerfile_csm-sles15sp3-barebones.image-recipe
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Dockerfile for image which holds the CSM barebones image (squashfs) and Kiwi recipe
-FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-imsload
+FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-imsload as base
 
 # Use for testing/not in pipeline builds
 #FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:latest as base

--- a/Dockerfile_csm-sles15sp3-barebones.image-recipe
+++ b/Dockerfile_csm-sles15sp3-barebones.image-recipe
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Dockerfile for image which holds the CSM barebones image (squashfs) and Kiwi recipe
-FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-imsload as base
+FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-imsload
 
 # Use for testing/not in pipeline builds
 #FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:latest as base
@@ -30,5 +30,5 @@ FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-ims
 # Copy the IMS import manifest
 COPY manifest.yaml /
 
-# Copy the image/recipe files
-COPY build/output/*product_version* /
+# Copy the image/recipe file
+COPY --chown=nobody:nobody build/output/*product_version* /

--- a/Dockerfile_csm-sles15sp3-barebones.image-recipe.dockerignore
+++ b/Dockerfile_csm-sles15sp3-barebones.image-recipe.dockerignore
@@ -26,5 +26,5 @@
 
 # But the following
 !/manifest.yaml
-!/build/output/*csm-1.2*
+!/build/output/*csm-1.3*
 !/gitInfo.txt

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ IMAGE_NAME ?= cray-shasta-csm-sles15sp3-barebones.x86_64
 DISTRO ?= sles15
 
 DOCKERFILE ?= Dockerfile_csm-sles15sp3-barebones.image-recipe
-BUILD_IMAGE ?= arti.dev.cray.com/cos-docker-master-local/cray-kiwi:latest
+BUILD_IMAGE ?= arti.hpc.amslabs.hpecorp.net/cos-docker-master-local/cray-kiwi:latest
 BUILD_SCRIPT ?= runKiwiBuild.sh
 RECIPE_DIRECTORY ?= kiwi-ng/cray-sles15sp3-barebones
 
@@ -79,6 +79,7 @@ kiwi_build_manifest:
 		${BUILD_IMAGE} \
 		bash -c 'ls -al /build && pwd && python3 create_init_ims_manifest.py --distro "${DISTRO}" --files "${FILES}" ${IMAGE_NAME}-${PRODUCT_VERSION}'
 	cat manifest.yaml
+	ls -la build/output/*
 
 kiwi_docker_image:
 	DOCKER_BUILDKIT=1 docker build --pull ${DOCKER_ARGS} -f ${DOCKERFILE} --tag '${NAME}:${DOCKER_VERSION}' .

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -41,10 +41,10 @@
 # For arti, if type is not specified, it defaults to stable
 #
 # For source docker, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-docker-<type>-local/repository.catalog
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-docker-<type>-local/repository.catalog
 #
 # For source helm, the image version will be based on the information found in:
-# https://arti.dev.cray.com/artifactory/<team>-helm-<type>-local/index.yaml
+# https://arti.hpc.amslabs.hpecorp.net/artifactory/<team>-helm-<type>-local/index.yaml
 #
 ###################
 # server: algol60 #
@@ -80,4 +80,4 @@
 
 image: cray-ims-load-artifacts
     major: 1
-    minor: 4
+    minor: 5

--- a/vars.sh
+++ b/vars.sh
@@ -24,7 +24,7 @@
 
 export PRODUCT_CSM="csm"
 export PRODUCT_COS="cos"
-export VERSION="csm-1.2"
+export VERSION="csm-1.3"
 
 # For developing for a master distribution, use 'master' here.
 # For developing for a release distribution, use product release version


### PR DESCRIPTION
## Summary and Scope

Added more detailed logging messages and some more error checking to help with diagnosing another problem like this if it should come up.  No functional changes to the code.

## Issues and Related PRs
* Resolves [CASMTRIAGE-3756](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3756)
* Resolves [CASMCMS-7970](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7970)
* Change will also be needed in the repo `image-recipes`

## Testing
### Tested on:
  * `surtur`

### Test description:

I uploaded new versions of the images and helm charts, then used helm/loftsman to uninstall/re-install the package.  This is not a running service, it just kicks off an import job that completes and exits.  After it completed the data import I verified it was correctly present in IMS and was able to be accessed for the barebones image boot test.  The boot test still failed, but that was due to BOA not having been updated for the new capmc API.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? N - not applicable
- Was upgrade tested? If not, why? N - not a running service
- Was downgrade tested? If not, why? N - not a running service
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations
This is a very low risk change as it only adds checking and logging.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
