### PR TITLE
CASMCMS-8252: Update Chart with correct version strings during builds; enable unstable artifact builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Fixed
 - Spelling corrections.
+- Update Chart with correct image and chart version strings during builds.
 
 ## [1.7.0] - 2022-08-11
 - CASMCMS-8075 - update the image and recipe to use sles15sp4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-8252: Enabled building of unstable artifacts
+- CASMCMS-8252: Updated header of update_versions.conf to reflect new tool options
+
 ### Fixed
 - Spelling corrections.
-- Update Chart with correct image and chart version strings during builds.
+- CASMCMS-8252: Update Chart with correct image and chart version strings during builds.
 
 ## [1.7.0] - 2022-08-11
 - CASMCMS-8075 - update the image and recipe to use sles15sp4.

--- a/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
+++ b/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
@@ -41,5 +41,5 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: cray-csm-barebones-recipe-install
-      image: artifactory.algol60.net/csm-docker/stable/cray-csm-sles15sp4-barebones-recipe:0.0.0-recipeimage
+      image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-csm-sles15sp4-barebones-recipe:0.0.0-recipeimage
   artifacthub.io/license: MIT

--- a/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
+++ b/kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-csm-barebones-recipe-install
-version: 0.0.0-recipe
+version: 0.0.0-recipechart
 description: Kubernetes resources for cray-csm-barebones-recipe-install
 keywords:
 - ims
@@ -41,5 +41,5 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: cray-csm-barebones-recipe-install
-      image: artifactory.algol60.net/csm-docker/stable/cray-csm-sles15sp4-barebones-recipe:0.0.0-recipe
+      image: artifactory.algol60.net/csm-docker/stable/cray-csm-sles15sp4-barebones-recipe:0.0.0-recipeimage
   artifacthub.io/license: MIT

--- a/kubernetes/cray-csm-barebones-recipe-install/values.yaml
+++ b/kubernetes/cray-csm-barebones-recipe-install/values.yaml
@@ -28,7 +28,7 @@
 cray-import-kiwi-recipe-image:
   import_image:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/cray-csm-sles15sp4-barebones-recipe
+      repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-csm-sles15sp4-barebones-recipe
 
   import_job:
     name: "product_name-image-recipe-import-product_version"

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -1,19 +1,22 @@
-#tag: version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
-#sourcefile: file to read actual version from (optional -- if unspecified, .version is assumed)
-#targetfile: file in which to have version tags replaced
+#tag: Version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
 #
-#Multiples of these lines are allowed. A given line is in effect until another line overrides it.
-#Example:
-#tag: @TAG1@
-#sourcefile: path/to/version1.txt
-#targetfile: my/file.py
-#targetfile: other/file.yaml
+#sourcefile: File to obtain the actual version from (optional -- if unspecified, .version is assumed)
+#            If this file is executable, it will be executed and the output will be used as the version string.
+#            Otherwise it will be read and its contents will be used as the version string, with any leading and
+#            trailing whitespace stripped. The version string is validated by the update_version.sh string to
+#            verify that they match the expected version formatting (essentially semver, with a minor exception
+#            -- see the script header for details).
+#sourcefile-novalidate: This is identical to the previous tag, except that the only validation that is
+#            done is to verify that the version string is not blank and does not contain strings which will
+#            disrupt the sed command used for the version tag replacement. Essentially, it cannot contain
+#            double quotes, forward slashes, or hash symbols. The file does still have leading and trailing
+#            whitespace stripped, however.
+#targetfile: file in which to have version tags replaced. When this line is reached, the replacement
+#            action is performed on this file.
 #
-#tag: @TAG2@
-#targetfile: a/b/c.txt
-#
-#sourcefile: v2.txt
-#targetfile: 1/2/3.txt
+#Multiples of any of these lines are allowed. A given line is in effect until another line overrides it.
+#For this purpose, the sourcefile and sourcefile-novalidate lines are considered the same (that is, they
+#override each other).
 
 sourcefile: .chart_version
 tag: 0.0.0-recipechart
@@ -22,6 +25,11 @@ targetfile: kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
 sourcefile: .docker_version
 tag: 0.0.0-recipeimage
 targetfile: kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
+
+sourcefile-novalidate: .stable
+tag: S-T-A-B-L-E
+targetfile: kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
+targetfile: kubernetes/cray-csm-barebones-recipe-install/values.yaml
 
 sourcefile: cray-ims-load-artifacts.version
 tag: 0.0.0-imsload

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -15,7 +15,12 @@
 #sourcefile: v2.txt
 #targetfile: 1/2/3.txt
 
-tag: 0.0.0-recipe
+sourcefile: .chart_version
+tag: 0.0.0-recipechart
+targetfile: kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
+
+sourcefile: .docker_version
+tag: 0.0.0-recipeimage
 targetfile: kubernetes/cray-csm-barebones-recipe-install/Chart.yaml
 
 sourcefile: cray-ims-load-artifacts.version


### PR DESCRIPTION
## Summary and Scope

### Use correct version strings

After Ryan noticed that a CFS build of his was not using the expected version strings in the Chart artifact, we looked into it and discovered that this was because the build was taking the docker and chart version strings from the wrong source. Specifically, it was taking them from the .version file, which did not include the "beta" tag that he was expecting. It should have been getting the docker and chart version strings from .docker_version and .chart_version respectively.

For tagged builds on the master branch, there is no difference in the contents of those files. But if doing builds in release branches, for example, the difference is apparent. 

I corrected the issue in the CFS repo with this PR:
https://github.com/Cray-HPE/config-framework-service/pull/51

I then reviewed all of the other CMS repos to see if the problem existed in any of them. I identified several others with the same issue. This PR is addressing the issue for this repository.

### Enable unstable artifacts

Currently the Chart.yaml and values.yaml files are hard-coded to point to stable directories on artifactory. The problem comes if an unstable artifact is built. That version of the docker image won't exist in that location out on artifactory, making the unstable chart unusable.

The fix is to adjust the path to stable or unstable based on the type of build being done. This was done in the BOS repo [with this PR](https://github.com/Cray-HPE/bos/pull/57) and in the CFS repo [with this PR](https://github.com/Cray-HPE/config-framework-service/pull/52).

I am making the change to this repository with this PR.

## Issues and Related PRs

* https://github.com/Cray-HPE/config-framework-service/pull/51
* https://github.com/Cray-HPE/config-framework-service/pull/52
* https://github.com/Cray-HPE/bos/pull/57

## Testing

None beyond making sure the build works and the artifacts get the correct version strings and paths.

## Risks and Mitigations

Very low risk. For master branch stable artifacts, this change has no effect.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
