### PR TITLE
CASMINST-5509: Backport of CASMTRIAGE-3756

### DIFF
--- a/Dockerfile_csm-sles15sp3-barebones.image-recipe
+++ b/Dockerfile_csm-sles15sp3-barebones.image-recipe
@@ -30,5 +30,5 @@ FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-ims
 # Copy the IMS import manifest
 COPY manifest.yaml /
 
-# Copy the image/recipe files
-COPY build/output/*product_version* /
+# Copy the image/recipe file
+COPY --chown=nobody:nobody build/output/*product_version* /

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ IMAGE_NAME ?= cray-shasta-csm-sles15sp3-barebones.x86_64
 DISTRO ?= sles15
 
 DOCKERFILE ?= Dockerfile_csm-sles15sp3-barebones.image-recipe
-BUILD_IMAGE ?= arti.dev.cray.com/cos-docker-master-local/cray-kiwi:latest
+BUILD_IMAGE ?= arti.hpc.amslabs.hpecorp.net/cos-docker-master-local/cray-kiwi:latest
 BUILD_SCRIPT ?= runKiwiBuild.sh
 RECIPE_DIRECTORY ?= kiwi-ng/cray-sles15sp3-barebones
 
@@ -79,6 +79,7 @@ kiwi_build_manifest:
 		${BUILD_IMAGE} \
 		bash -c 'ls -al /build && pwd && python3 create_init_ims_manifest.py --distro "${DISTRO}" --files "${FILES}" ${IMAGE_NAME}-${PRODUCT_VERSION}'
 	cat manifest.yaml
+	ls -la build/output/*
 
 kiwi_docker_image:
 	DOCKER_BUILDKIT=1 docker build --pull ${DOCKER_ARGS} -f ${DOCKERFILE} --tag '${NAME}:${DOCKER_VERSION}' .

--- a/create_init_ims_manifest.py
+++ b/create_init_ims_manifest.py
@@ -27,6 +27,8 @@ import yaml
 import hashlib
 import json
 import re
+import os
+import stat
 
 ARTIFACT_MAPPING = {
     "kernel":          "application/vnd.cray.image.kernel",
@@ -69,6 +71,7 @@ def create_manifest(files, distro, image_name):
 
 def update_artifact_list(artifact, arti_type):
     original_artifact = artifact
+    fix_file_perms(original_artifact)
     artifact = re.sub('^(.*[\\\/])', '', artifact)
     new_item = {
         'link': {
@@ -95,6 +98,19 @@ def update_recipe_list(recipe, distro):
     }
 
     return new_item
+
+
+def fix_file_perms(filename):
+    """
+    Make sure the file is universally readable
+
+    NOTE: this is required since the build env is running under the root
+    user, but the images that package the artifacts are not.  Make sure
+    all artifacts are publicly readable so the next comsumer can read them.
+    """
+    read_mask = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    curr_perms = stat.S_IMODE(os.lstat(filename).st_mode)
+    os.chmod(filename, curr_perms | read_mask)
 
 
 def get_md5sum(filename):


### PR DESCRIPTION
## Summary and Scope

This is a csm-1.2 backport of: https://github.com/Cray-HPE/image-recipes/pull/25

The root cause of CASMTRIAGE-3756 was a change in the base image build environment. The fix was only made to csm-1.3, but we are now seeing it in 1.2.2. This PR backports the fix to our csm-1.2 branch, to correct the issue.

## Issues and Related PRs

* [CASMTRIAGE-3756](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3756)
* https://github.com/Cray-HPE/ims-load-artifacts/pull/19
* https://github.com/Cray-HPE/ims-load-artifacts/pull/28
* https://github.com/Cray-HPE/image-recipes/pull/25

## Testing

The change being made is independent of the CSM version, so the testing from the previous PR should still be applicable.

## Risks and Mitigations

Without this fix, the barebones image build fails during installs.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
