### PR TITLE
CASMTRIAGE-4950 - update csm release version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2023-02-24
+### Changed
+- CASMTRIAGE-4950 - update the csm version in the recipe name.
+
 ## [1.7.1] - 2022-12-21
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/Dockerfile_csm-sles15sp4-barebones.image-recipe.dockerignore
+++ b/Dockerfile_csm-sles15sp4-barebones.image-recipe.dockerignore
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,5 +26,5 @@
 
 # But the following
 !/manifest.yaml
-!/build/output/*csm-1.3*
+!/build/output/*csm-1.4*
 !/gitInfo.txt

--- a/vars.sh
+++ b/vars.sh
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 
 export PRODUCT_CSM="csm"
 export PRODUCT_COS="cos"
-export VERSION="csm-1.3"
+export VERSION="csm-1.4"
 
 export SLES_VERSION="15"
 export SLES_SP="SP4"


### PR DESCRIPTION
## Summary and Scope

Update the csm release to 1.4.

## Issues and Related PRs
* Resolves [CASMTRIAGE-4950](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4950)

## Testing
### Tested on:
  * `Surtur`

### Test description:

Installed via helm on surtur and verified the name of the image and recipe was at the correct 'csm-1.4' instead of the incorrect 'csm-1.3'.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just changing the name of the installed files.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

