### PR TITLE
CASMCMS-8472: Use artifactory authentication instead of unauthenticated mirrors, where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-8472: Build using artifactory authentication instead of unauthenticated mirrors, where possible
 
 ## [1.7.3] - 2023-03-14
 ### Changed

--- a/Dockerfile_csm-sles15sp4-barebones.image-recipe
+++ b/Dockerfile_csm-sles15sp4-barebones.image-recipe
@@ -22,10 +22,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Dockerfile for image which holds the CSM barebones image (squashfs) and Kiwi recipe
-FROM arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cray-ims-load-artifacts:0.0.0-imsload as base
+FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:0.0.0-imsload as base
 
 # Use for testing/not in pipeline builds
-#FROM arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cray-ims-load-artifacts:latest as base
+#FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:latest as base
 
 # Copy the IMS import manifest
 COPY manifest.yaml /

--- a/vars.sh
+++ b/vars.sh
@@ -27,7 +27,8 @@ export PRODUCT_COS="cos"
 export VERSION="csm-1.4"
 
 export SLES_VERSION="15"
-export SLES_SP="SP4"
+export SLES_SPNUM=4
+export SLES_SP="SP${SLES_SPNUM}"
 export SLES_ARCH="x86_64"
 
 # For developing for a master distribution, use 'master' here.
@@ -55,6 +56,6 @@ fi
 ## NOTE: ARTIFACTORY_USER and ARTIFACTORY_TOKEN are defined in the jenkinsfile
 ##  by the 'withCredentials' function and passed through the docker call in
 ##  the Makefile.
-export BLOBLET_CSM="https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpms-remote/hpe/stable/sle-15sp4"
+export BLOBLET_CSM="https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${SLES_VERSION}sp${SLES_SPNUM}"
 export BLOBLET_COS="https://arti.hpc.amslabs.hpecorp.net/artifactory/${PRODUCT_COS}-rpm-stable-local/release/${PRODUCT_COS}-${COS_RELEASE_VERSION}"
 export BLOBLET_OS="https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror"


### PR DESCRIPTION
## Summary and Scope

@dlaine-hpe informed me that as a team, we're trying to avoid using the HPE internal unauthenticated mirrors in our builds, and instead access the original repositories using authentication.

Earlier this week I modified the image-recipes repository to use the internal mirrors. This PR reverts those changes.

I also made a slight improvement to the `vars.sh` file to make it easier to keep things in sync if we change the SLES version or SP in the future.

Note that this repository still does use unauthenticated mirrors (and did so before my work this week). As far as I can tell, this is necessary to access COS images and RPMs, as they are not present on our usual artifactory server.

## Testing

No testing beyond making sure that the build still passes.

## Risks and Mitigations

Low risk -- building using the same repositories, just changing how we access them.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
