### PR TITLE
CASMTRIAGE-5163: Change to version 3.2 of the base chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update to use update_external_version to get latest patch version of base chart
 - Update chart maintainers
+- CASMTRIAGE-5163: Change to version 3.2 of the base chart (cray-import-kiwi-recipe-image)
 
 ## [1.7.4] - 2023-03-17
 

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -84,5 +84,5 @@ image: cray-ims-load-artifacts
 
 image: cray-import-kiwi-recipe-image
     source: helm
-    major: 2
-    minor: 0
+    major: 3
+    minor: 2


### PR DESCRIPTION
## Summary and Scope

Because we are using an older version of the Cray Product Catalog to import the CSM barebones image, on upgrades to CSM 1.4, data is lost in the product catalog.

The cray-import-kiwi-recipe-image chart version 3.2.0 now uses the latest CPC version.
This PR updates the barebones installer to use version 3.2 of the base image. See [CASMTRIAGE-5163](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5163) for details.

## Testing

The new version of the CPC has been extensively tested even before this -- it just wasn't being used for this one case of updating the product catalog.

## Risks and Mitigations

Without this, the CPC will lose data during CSM upgrades.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
