### PR TITLE
CASM-3868: Use version 2.3 of cray-ims-load-artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CASM-3868: Use version 2.3 of cray-ims-load-artifacts
+
 ## [1.8.0] - 2023-04-06
 
 ### Changed

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,7 +80,7 @@
 
 image: cray-ims-load-artifacts
     major: 2
-    minor: 2
+    minor: 3
 
 image: cray-import-kiwi-recipe-image
     source: helm


### PR DESCRIPTION
## Summary and Scope

ims-python-helper was updated to address [CASMINST-6081](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6081) and [CASM-3868](https://jira-pro.its.hpecorp.net:8443/browse/CASM-3868).
ims-load-artifacts was updated to pull in that updated version of ims-python-helper.
This PR updates image-recipes to use the updated version of ims-load-artifacts.
