### PR TITLE
CASMCMS-7922: Used updated ims-load-artifacts and cray-import-kiwi-recipe-image in order to create BOS v2 session templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-05-23
+
+### Changed
+
+- CASMCMS-7922: Use version 2.5 of cray-ims-load-artifacts and version 4.0 of cray-import-kiwi-recipe-image, in
+  order to create BOS session templates using BOS v2.
+
 ## [1.10.0] - 2023-05-23
 
 ### Changed

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,9 +80,9 @@
 
 image: cray-ims-load-artifacts
     major: 2
-    minor: 4
+    minor: 5
 
 image: cray-import-kiwi-recipe-image
     source: helm
-    major: 3
-    minor: 2
+    major: 4
+    minor: 0


### PR DESCRIPTION
## Summary and Scope

Moving to those versions will mean that when the images from this repo create associated BOS session templates, they will be created using BOS v2.

## Issues and Related PRs

* This should not merge until [this PR](https://github.com/Cray-HPE/ims-load-artifacts/pull/59) is merged to develop, merged to master, and then tagged as v2.5.0.
* Partially resolves [CASMCMS-7922](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-7922)

