### PR TITLE
Release v2.3.0 - update MTL compute image version for csm-1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2023-08-16
+- CASMCMS-8743 - update the MTL compute image version for csm-1.6 release.
+
 ## [2.2.0] - 2023-08-16
 ## Added
 - CASMCMS-8743 - include MTL compute images and fix bos session template generation.

--- a/scripts/runImageDownload.sh
+++ b/scripts/runImageDownload.sh
@@ -26,7 +26,8 @@
 set -ex
 
 # Get the current version of the MTL compute image 'COMPUTE_IMAGE_ID'
-source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Cray-HPE/csm/release/1.5/assets.sh)"
+# NOTE: change this line for updated csm releases:
+source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/Cray-HPE/csm/release/1.6/assets.sh)"
 
 # Get the other defined vars
 source scripts/vars.sh


### PR DESCRIPTION
## Summary and Scope

Update the location the MTL compute version is defined to pull from the csm-1.6 manifest location.

## Issues and Related PRs
* Resolves [CASMCMS-8743](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8743)

## Testing
### Tested on:
  * `Mug`

### Test description:

Installed via helm and verified artifacts worked as needed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk - just changing location version information is pulled from.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

