### PR TITLE
CASMCMS-8973: Builds failing with permission errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - CASMCMS-8973: Remove unnecessary build artifacts before creating final Docker image, to avoid permission problems.
+- CASMCMS-8973: Remove redundant `DOCKER_VERSION` variable assignment from Jenkinsfile
 
 ## [2.5.0] - 2024-02-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-8973: Remove unnecessary build artifacts before creating final Docker image, to avoid permission problems.
 
 ## [2.5.0] - 2024-02-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.5.1] - 2024-04-24
 ### Changed
 - CASMCMS-8973: Remove unnecessary build artifacts before creating final Docker image, to avoid permission problems.
 - CASMCMS-8973: Remove redundant `DOCKER_VERSION` variable assignment from Jenkinsfile

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -92,7 +92,6 @@ pipeline {
 
                 stage('Chart') {
                     environment {
-                        DOCKER_VERSION = sh(returnStdout: true, script: "head -1 .docker_version").trim()
                         CHART_VERSION = sh(returnStdout: true, script: "head -1 .chart_version").trim()
                     }
                     steps {


### PR DESCRIPTION
Starting over a month ago, all `image-recipes` builds started failing when trying to do the final Docker image build. The errors look like:

```text
[2024-04-16T09:47:25.293Z] DOCKER_BUILDKIT=1 docker build --pull  --secret id=netrc,src=/home/jenkins/.netrc --secret id=ARTIFACTORY_READONLY_USER,src=/home/jenkins/.config/secrets/ARTIFACTORY_READONLY_USER --secret id=ARTIFACTORY_READONLY_TOKEN,src=/home/jenkins/.config/secrets/ARTIFACTORY_READONLY_TOKEN --label "org.label-schema.name=cray-csm-sles15sp5-barebones-recipe" --label "org.label-schema.description=Cray System Management (CSM) Barebones Recipes and Images" --label "org.label-schema.version=2.5.0" --label "org.label-schema.vcs-tag=v2.5.0" --label "org.label-schema.build-date=2024-04-16T09:41:34Z" --label "org.label-schema.build-url=https://jenkins.algol60.net/job/Cray-HPE/job/image-recipes/job/v2.5.0/" --label "org.label-schema.url=http://www.cray.com/" --label "org.label-schema.vcs-url=https://github.com/Cray-HPE/image-recipes.git" --label "org.label-schema.vcs-ref=2fc2b42667601aede6f1636b207c4bc43ef28ae6" --label "org.label-schema.vendor=Cray Inc" --label "org.label-schema.schema-version=1.0" -f Dockerfile_csm-sles15sp5-barebones.image-recipe --tag 'cray-csm-sles15sp5-barebones-recipe:2.5.0' .
[2024-04-16T09:47:25.293Z] #0 building with "default" instance using docker driver
[2024-04-16T09:47:25.293Z] 
[2024-04-16T09:47:25.293Z] #1 [internal] load .dockerignore
[2024-04-16T09:47:25.293Z] #1 transferring context: 2B done
[2024-04-16T09:47:25.293Z] #1 DONE 0.0s
[2024-04-16T09:47:25.293Z] 
[2024-04-16T09:47:25.293Z] #2 [internal] load build definition from Dockerfile_csm-sles15sp5-barebones.image-recipe
[2024-04-16T09:47:25.293Z] #2 transferring dockerfile: 3.07kB done
[2024-04-16T09:47:25.293Z] #2 DONE 0.0s
[2024-04-16T09:47:25.293Z] 
[2024-04-16T09:47:25.293Z] #3 [auth] csm-docker/stable/cray-ims-load-artifacts:pull stable/cray-ims-load-artifacts:pull token for artifactory.algol60.net
[2024-04-16T09:47:25.293Z] #3 DONE 0.0s
[2024-04-16T09:47:25.293Z] 
[2024-04-16T09:47:25.293Z] #4 [internal] load metadata for artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.7.1
[2024-04-16T09:47:25.293Z] #4 DONE 0.1s
[2024-04-16T09:47:25.293Z] 
[2024-04-16T09:47:25.293Z] #5 [internal] load build context
[2024-04-16T09:47:25.293Z] #5 transferring context: 73B done
[2024-04-16T09:47:25.293Z] #5 ERROR: error from sender: open build/output/build/image-root/etc/lvm/archive: permission denied
[2024-04-16T09:47:25.293Z] 
[2024-04-16T09:47:25.293Z] #6 [1/5] FROM artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.7.1@sha256:600216aeee8aff73d1c9b3e12e50f55d4a54d4e09a7ad91f6f3fb98480c271e0
[2024-04-16T09:47:25.293Z] #6 resolve artifactory.algol60.net/csm-docker/stable/cray-ims-load-artifacts:2.7.1@sha256:600216aeee8aff73d1c9b3e12e50f55d4a54d4e09a7ad91f6f3fb98480c271e0 0.0s done
[2024-04-16T09:47:25.293Z] #6 sha256:600216aeee8aff73d1c9b3e12e50f55d4a54d4e09a7ad91f6f3fb98480c271e0 1.99kB / 1.99kB done
[2024-04-16T09:47:25.293Z] #6 sha256:5b35534b5e9ef67a8ea381e8699a710261666dab63424b2ffe9998f2cfb1953a 5.04kB / 5.04kB done
[2024-04-16T09:47:25.293Z] #6 CANCELED
[2024-04-16T09:47:25.293Z] ------
[2024-04-16T09:47:25.293Z]  > [internal] load build context:
[2024-04-16T09:47:25.293Z] ------
[2024-04-16T09:47:25.293Z] ERROR: failed to solve: error from sender: open build/output/build/image-root/etc/lvm/archive: permission denied
[2024-04-16T09:47:25.293Z] make: *** [Makefile:98: kiwi_docker_image] Error 1
```

Investigation revealed that earlier steps in the build process were creating artifacts in the `build/output/build` tree, all of which are owned by root, and some of which are not readable by the Jenkins user.

My guess is that builds started hitting this failure for one of two reasons:
1) Previously the build artifacts did not contain any files which the Jenkins user could not read
or
2) Our build environment changed and started using a Docker version which cared about these permissions, whereas the previous version did not.

It turns out that the files with the bad permissions are ones we don't even need for the final build. They just exist in the tree under the current directory, and I guess that upsets Docker. They aren't actually used in the image we're trying to build. So this PR just modifies an earlier step to delete the `build/output/build` directory, once it has served its purpose, and before we do the final build.

Doing the above revealed that unreadable files were also contained under `build/unpack`, another directory we do not need for the final build, so off with its head as well.

I've confirmed that this allows the builds to once again proceed.

I'd rather make a "smarter" edit that knows all of the artifacts we DO care about, and deletes everything else, but for now my primary concern is getting the builds working again.