### PR TITLE
CASMCMS-9066: Fix build break: Add procps to bootstrap package list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9066: Add `procps` to `bootstrap` package list in `kiwi-ng/cray-sles15sp5-barebones/config-template.xml.j2`,
+  to fix build failure.
+
 ## [2.5.1] - 2024-04-24
 ### Changed
 - CASMCMS-8973: Remove unnecessary build artifacts before creating final Docker image, to avoid permission problems.

--- a/kiwi-ng/cray-sles15sp5-barebones/config-template.xml.j2
+++ b/kiwi-ng/cray-sles15sp5-barebones/config-template.xml.j2
@@ -138,6 +138,7 @@
         <package name="xorriso"/>
     </packages>
     <packages type="bootstrap">
+        <package name="procps"/>
         <package name="udev"/>
         <package name="filesystem"/>
         <package name="glibc-locale"/>


### PR DESCRIPTION
See [CASMCMS-9066](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9066) for a background on this issue and how I arrived at this PR.

The short version is that the builds in this repo started failing one day, and I noticed that the procps package had previously been being installed automatically (pulled in as a dependency of something, I assume), whereas on the failing builds this was not the case. The errors showing up in the failing builds led me to believe that the absence of this package was possibly the culprit, so I tested to see if adding the package explicitly would fix the problem. That resulted in the builds working once again. This PR contains those changes.

I am not an expert in this area, and I don't know if this is the "right" fix for us to make. But we need to do something if we want the builds to work, and this seems to basically make them work the way they did before.

This will need to be backported to any release branches that we want to rebuild, because I've verified that this happens to them as well.